### PR TITLE
fix: correct 'partys' to 'Parties' in _PARTY_LABELS (issue #113)

### DIFF
--- a/ckan/src/ckanext-pidinst-theme/ckanext/pidinst_theme/helpers.py
+++ b/ckan/src/ckanext-pidinst-theme/ckanext/pidinst_theme/helpers.py
@@ -642,6 +642,7 @@ _PARTY_LABELS = {
     'create label': 'Add Party',
     'update label': 'Update Party',
     'breadcrumb': 'Parties',
+    'facet label': 'Parties',
     'main nav': 'Parties',
     'no label found': 'Party',
 }


### PR DESCRIPTION
## Summary
Fix the plural spelling typo for the 'party' group type: 'partys' → 'Parties'.

## Root Cause
`_PARTY_LABELS` was missing the `'facet label': 'Parties'` entry. When CKAN calls `humanize_entity_type('group', 'party', 'facet label')`, the override falls back to `'Party'`, and CKAN core's naive pluralization produces 'partys' instead of the correct 'Parties'.

## Fix
Added `'facet label': 'Parties'` to `_PARTY_LABELS` in `helpers.py`.

## Changes
- `ckanext-pidinst-theme/ckanext/pidinst_theme/helpers.py`: +1 line

Fixes #113.